### PR TITLE
ISSUE 38 - bug fix for not working on NativeScript 6.4

### DIFF
--- a/src/loading-indicator.android.ts
+++ b/src/loading-indicator.android.ts
@@ -1,9 +1,9 @@
-import * as application from '@nativescript/core/application';
-import { Color } from '@nativescript/core/color';
-import { ImageSource } from '@nativescript/core/image-source';
-import { screen } from '@nativescript/core/platform';
-import { Frame } from '@nativescript/core/ui/frame';
-import { ad as androidUtils } from '@nativescript/core/utils/utils';
+import * as application from 'tns-core-modules/application';
+import { Color } from 'tns-core-modules/color';
+import { ImageSource } from 'tns-core-modules/image-source';
+import { screen } from 'tns-core-modules/platform';
+import { Frame } from 'tns-core-modules/ui/frame';
+import { ad as androidUtils } from 'tns-core-modules/utils/utils';
 import { Mode, OptionsCommon } from './loading-indicator.common';
 
 export * from './loading-indicator.common';

--- a/src/loading-indicator.ios.ts
+++ b/src/loading-indicator.ios.ts
@@ -1,4 +1,4 @@
-import { Color } from '@nativescript/core/color';
+import { Color } from 'tns-core-modules/color';
 import { Mode, OptionsCommon } from './loading-indicator.common';
 
 export * from './loading-indicator.common';

--- a/src/package.json
+++ b/src/package.json
@@ -80,16 +80,18 @@
   "homepage": "https://github.com/nstudio/nativescript-loading-indicator",
   "readmeFilename": "README.md",
   "devDependencies": {
+    "@nativescript/core": "^6.3.2",
     "husky": "^4.2.0",
     "lint-staged": "^10.0.2",
     "prettier": "^1.19.1",
-    "@nativescript/core": "^6.3.2",
-    "tns-platform-declarations": "^6.3.2",
-    "typescript": "~3.7.4",
     "prompt": "^1.0.0",
     "rimraf": "^2.6.3",
+    "semver": "^5.6.0",
+    "tns-platform-declarations": "^6.4.1",
     "tslint": "^5.20.1",
-    "semver": "^5.6.0"
+    "typescript": "~3.7.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "tns-core-modules": "^6.4.1"
+  }
 }


### PR DESCRIPTION
I am using NativeScript 6.4.0 and Angular 8. There was an issue where @nativescript did not exist and it would not compile or run on iOS so I used tsn-core-modules instead and it works now.