### PR TITLE
fix(loading-indicator.ios): allow message to line break in iOS

### DIFF
--- a/src/loading-indicator.ios.ts
+++ b/src/loading-indicator.ios.ts
@@ -26,6 +26,8 @@ export class LoadingIndicator {
     // options
     if (options.message) {
       this._hud.label.text = options.message;
+      // allow line breaking
+      this._hud.label.numberOfLines = 0;
     }
 
     if (options.progress) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it. https://github.com/nstudio/nativescript-loading-indicator/issues/42
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Long messages do not line break in iOS

## What is the new behavior?
Long messages will break to the next line in iOS

Fixes #42 

