### PR TITLE
fix "Cannot read property 'android' of undefined"

### DIFF
--- a/src/loading-indicator.android.ts
+++ b/src/loading-indicator.android.ts
@@ -379,9 +379,6 @@ export class LoadingIndicator {
 
     contentView.addView(parentView);
     this._popOver.setContentView(contentView);
-    const view =
-      Frame.topmost().android.rootViewGroup ||
-      Frame.topmost().currentPage.android;
 
     // handle anchoring target view
     if (options.android && options.android.view) {
@@ -395,6 +392,10 @@ export class LoadingIndicator {
         0
       );
     } else {
+      const view =
+        Frame.topmost().android.rootViewGroup ||
+        Frame.topmost().currentPage.android;
+
       this._popOver.setWidth(Screen.mainScreen.widthPixels);
       this._popOver.setHeight(Screen.mainScreen.heightPixels);
       this._popOver.showAtLocation(view, android.view.Gravity.CENTER, 0, 0);


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
An error occurs even if the `option.android.view` is specified for the absence of a frame (e.g. rootView is Layout, BottomNavigation).
> Error creating Loading Indicator Pop Over: Cannot read property 'android' of undefined

## What is the new behavior?
When the `option.android.view` is specified, no error occurs if the `Frame.topmost()` is undefined.
Fixes #2 
